### PR TITLE
RHCLOUD-46704 - Implement principal from RH identity helpers

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -185,6 +185,21 @@
             </build>
         </profile>
         <profile>
+            <id>run-console-principal</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.6.2</version>
+                        <configuration>
+                            <mainClass>org.project_kessel.examples.ConsolePrincipalExample</mainClass>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>run-check-bulk</id>
             <build>
                 <plugins>

--- a/examples/src/main/java/org/project_kessel/examples/ConsolePrincipalExample.java
+++ b/examples/src/main/java/org/project_kessel/examples/ConsolePrincipalExample.java
@@ -1,0 +1,48 @@
+package org.project_kessel.examples;
+
+import java.util.Base64;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.project_kessel.api.console.Console;
+import org.project_kessel.api.inventory.v1beta2.SubjectReference;
+
+public class ConsolePrincipalExample {
+
+    public static void main(String[] args) throws Exception {
+        // --- From a parsed User identity map ---
+        Map<String, Object> userIdentity = Map.of(
+                "type", "User",
+                "org_id", "12345",
+                "user", Map.of("user_id", "7393748", "username", "jdoe"));
+
+        SubjectReference subject = Console.principalFromRHIdentity(userIdentity);
+        System.out.println("User principal:            " + subject.getResource().getResourceId());
+
+        // --- From a parsed ServiceAccount identity map ---
+        Map<String, Object> saIdentity = Map.of(
+                "type", "ServiceAccount",
+                "org_id", "456",
+                "service_account", Map.of(
+                        "user_id", "12345",
+                        "client_id", "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                        "username", "service-account-b69eaf9e"));
+
+        subject = Console.principalFromRHIdentity(saIdentity);
+        System.out.println("ServiceAccount principal:  " + subject.getResource().getResourceId());
+
+        // --- From a raw base64-encoded x-rh-identity header ---
+        Map<String, Object> headerPayload = Map.of(
+                "identity", Map.of(
+                        "type", "User",
+                        "org_id", "12345",
+                        "user", Map.of("user_id", "7393748", "username", "jdoe")));
+
+        String header = Base64.getEncoder().encodeToString(
+                new ObjectMapper().writeValueAsBytes(headerPayload));
+
+        subject = Console.principalFromRHIdentityHeader(header);
+        System.out.println("From header principal:     " + subject.getResource().getResourceId());
+    }
+}

--- a/kessel-sdk/src/main/java/org/project_kessel/api/common/JsonMapper.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/common/JsonMapper.java
@@ -1,0 +1,15 @@
+package org.project_kessel.api.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public final class JsonMapper {
+
+    private static final ObjectMapper INSTANCE = new ObjectMapper();
+
+    private JsonMapper() {
+    }
+
+    public static ObjectMapper instance() {
+        return INSTANCE;
+    }
+}

--- a/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
@@ -2,20 +2,21 @@ package org.project_kessel.api.console;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.project_kessel.api.common.JsonMapper;
 import org.project_kessel.api.inventory.v1beta2.SubjectReference;
 import org.project_kessel.api.rbac.v2.Utils;
 
 public class Console {
 
     private static final String DEFAULT_DOMAIN = "redhat";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final List<String> SUPPORTED_TYPES = List.of("User", "ServiceAccount");
+    private static final Map<String, String> SUPPORTED_TYPES = Map.of(
+            "User", "user",
+            "ServiceAccount", "service_account"
+    );
 
     private Console() {
     }
@@ -27,15 +28,11 @@ public class Console {
 
         Object typeObj = identity.get("type");
         String type = typeObj instanceof String ? (String) typeObj : null;
-        String field;
+        String field = type != null ? SUPPORTED_TYPES.get(type) : null;
 
-        if ("User".equals(type)) {
-            field = "user";
-        } else if ("ServiceAccount".equals(type)) {
-            field = "service_account";
-        } else {
+        if (field == null) {
             throw new IllegalArgumentException(
-                    "Unsupported identity type: \"" + typeObj + "\" (supported: " + SUPPORTED_TYPES + ")");
+                    "Unsupported identity type: \"" + typeObj + "\" (supported: " + SUPPORTED_TYPES.keySet() + ")");
         }
 
         Object details = identity.get(field);
@@ -70,7 +67,7 @@ public class Console {
         Map<String, Object> decoded;
         try {
             byte[] bytes = Base64.getDecoder().decode(header);
-            decoded = OBJECT_MAPPER.readValue(
+            decoded = JsonMapper.instance().readValue(
                     new String(bytes, StandardCharsets.UTF_8),
                     new TypeReference<Map<String, Object>>() {
                     });

--- a/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
@@ -1,0 +1,98 @@
+package org.project_kessel.api.console;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.project_kessel.api.inventory.v1beta2.SubjectReference;
+import org.project_kessel.api.rbac.v2.Utils;
+
+public class Console {
+
+    private static final String DEFAULT_DOMAIN = "redhat";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final List<String> SUPPORTED_TYPES = List.of("User", "ServiceAccount");
+
+    private Console() {
+    }
+
+    static String extractUserID(Map<String, Object> identity) {
+        if (identity == null) {
+            throw new IllegalArgumentException("identity must not be null");
+        }
+
+        String type = (String) identity.get("type");
+        String field;
+
+        if ("User".equals(type)) {
+            field = "user";
+        } else if ("ServiceAccount".equals(type)) {
+            field = "service_account";
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported identity type: \"" + type + "\" (supported: " + SUPPORTED_TYPES + ")");
+        }
+
+        Object details = identity.get(field);
+        if (!(details instanceof Map)) {
+            throw new IllegalArgumentException(
+                    "Identity type \"" + type + "\" is missing the \"" + field + "\" field");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> detailsMap = (Map<String, Object>) details;
+        Object userIdObj = detailsMap.get("user_id");
+        String userId = userIdObj != null ? userIdObj.toString() : null;
+
+        if (userId == null || userId.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Unable to resolve user ID from " + type + " identity (tried: user_id)");
+        }
+
+        return userId;
+    }
+
+    public static SubjectReference principalFromRHIdentity(Map<String, Object> identity, String domain) {
+        String userId = extractUserID(identity);
+        return Utils.principalSubject(userId, domain);
+    }
+
+    public static SubjectReference principalFromRHIdentity(Map<String, Object> identity) {
+        return principalFromRHIdentity(identity, DEFAULT_DOMAIN);
+    }
+
+    public static SubjectReference principalFromRHIdentityHeader(String header, String domain) {
+        Map<String, Object> decoded;
+        try {
+            byte[] bytes = Base64.getDecoder().decode(header);
+            decoded = OBJECT_MAPPER.readValue(
+                    new String(bytes, StandardCharsets.UTF_8),
+                    new TypeReference<Map<String, Object>>() {
+                    });
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to decode identity header: " + e.getMessage(), e);
+        }
+
+        Object identityObj = decoded.get("identity");
+        if (identityObj == null) {
+            throw new IllegalArgumentException("Identity header is missing the \"identity\" envelope key");
+        }
+
+        if (!(identityObj instanceof Map)) {
+            throw new IllegalArgumentException("Identity header did not decode to a JSON object");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> identity = (Map<String, Object>) identityObj;
+
+        return principalFromRHIdentity(identity, domain);
+    }
+
+    public static SubjectReference principalFromRHIdentityHeader(String header) {
+        return principalFromRHIdentityHeader(header, DEFAULT_DOMAIN);
+    }
+}

--- a/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
@@ -25,7 +25,8 @@ public class Console {
             throw new IllegalArgumentException("identity must not be null");
         }
 
-        String type = (String) identity.get("type");
+        Object typeObj = identity.get("type");
+        String type = typeObj instanceof String ? (String) typeObj : null;
         String field;
 
         if ("User".equals(type)) {
@@ -34,7 +35,7 @@ public class Console {
             field = "service_account";
         } else {
             throw new IllegalArgumentException(
-                    "Unsupported identity type: \"" + type + "\" (supported: " + SUPPORTED_TYPES + ")");
+                    "Unsupported identity type: \"" + typeObj + "\" (supported: " + SUPPORTED_TYPES + ")");
         }
 
         Object details = identity.get(field);
@@ -57,6 +58,9 @@ public class Console {
     }
 
     public static SubjectReference principalFromRHIdentity(Map<String, Object> identity, String domain) {
+        if (domain == null || domain.trim().isEmpty()) {
+            throw new IllegalArgumentException("domain must not be null or blank");
+        }
         String userId = extractUserID(identity);
         return Utils.principalSubject(userId, domain);
     }

--- a/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/console/Console.java
@@ -58,9 +58,6 @@ public class Console {
     }
 
     public static SubjectReference principalFromRHIdentity(Map<String, Object> identity, String domain) {
-        if (domain == null || domain.trim().isEmpty()) {
-            throw new IllegalArgumentException("domain must not be null or blank");
-        }
         String userId = extractUserID(identity);
         return Utils.principalSubject(userId, domain);
     }

--- a/kessel-sdk/src/main/java/org/project_kessel/api/rbac/v2/FetchWorkspace.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/rbac/v2/FetchWorkspace.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.project_kessel.api.auth.AuthRequest;
 import org.project_kessel.api.auth.OAuth2Exception;
+import org.project_kessel.api.common.JsonMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -14,7 +15,7 @@ import java.net.http.HttpResponse;
 public class FetchWorkspace {
 
     private static final String WORKSPACE_ENDPOINT = "/api/rbac/v2/workspaces/";
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapper.instance();
 
     public static Workspace fetchRootWorkspace(String rbacBaseEndpoint, String orgId)
             throws IOException, InterruptedException, OAuth2Exception {

--- a/kessel-sdk/src/test/java/org/project_kessel/api/console/ConsoleTest.java
+++ b/kessel-sdk/src/test/java/org/project_kessel/api/console/ConsoleTest.java
@@ -1,0 +1,274 @@
+package org.project_kessel.api.console;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.project_kessel.api.inventory.v1beta2.SubjectReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConsoleTest {
+
+    @Nested
+    class ExtractUserIDTest {
+        @Test
+        void testUserWithUserId() {
+            Map<String, Object> identity = Map.of(
+                    "type", "User",
+                    "user", Map.of("user_id", "7393748", "username", "foobar"));
+            assertEquals("7393748", Console.extractUserID(identity));
+        }
+
+        @Test
+        void testUserMissingUserId() {
+            Map<String, Object> identity = Map.of(
+                    "type", "User",
+                    "user", Map.of("username", "foobar"));
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("Unable to resolve user ID"));
+        }
+
+        @Test
+        void testUserEmptyUserId() {
+            Map<String, Object> identity = Map.of(
+                    "type", "User",
+                    "user", Map.of("user_id", ""));
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("Unable to resolve user ID"));
+        }
+
+        @Test
+        void testServiceAccountWithUserId() {
+            Map<String, Object> identity = Map.of(
+                    "type", "ServiceAccount",
+                    "service_account", Map.of("user_id", "sa-456", "client_id", "b69eaf9e"));
+            assertEquals("sa-456", Console.extractUserID(identity));
+        }
+
+        @Test
+        void testServiceAccountMissingUserId() {
+            Map<String, Object> identity = Map.of(
+                    "type", "ServiceAccount",
+                    "service_account", Map.of("client_id", "b69eaf9e"));
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("Unable to resolve user ID"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "System", "X509", "Associate" })
+        void testUnsupportedIdentityType(String type) {
+            Map<String, Object> identity = Map.of("type", type);
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("Unsupported identity type"));
+        }
+
+        @Test
+        void testMissingTypeField() {
+            Map<String, Object> identity = Map.of("org_id", "123");
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("Unsupported identity type"));
+        }
+
+        @Test
+        void testMissingUserDetails() {
+            Map<String, Object> identity = Map.of("type", "User");
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("missing the \"user\" field"));
+        }
+
+        @Test
+        void testMissingServiceAccountDetails() {
+            Map<String, Object> identity = Map.of("type", "ServiceAccount");
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("missing the \"service_account\" field"));
+        }
+
+        @Test
+        void testUserDetailsNotAMap() {
+            Map<String, Object> identity = Map.of("type", "User", "user", "not-a-map");
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(identity));
+            assertTrue(ex.getMessage().contains("missing the \"user\" field"));
+        }
+
+        @Test
+        void testNullIdentity() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.extractUserID(null));
+            assertTrue(ex.getMessage().contains("identity must not be null"));
+        }
+    }
+
+    @Nested
+    class PrincipalFromRHIdentityTest {
+        @Test
+        void testUserIdentity() {
+            Map<String, Object> identity = Map.of(
+                    "type", "User",
+                    "org_id", "1979710",
+                    "user", Map.of("user_id", "7393748", "username", "foobar"));
+            SubjectReference ref = Console.principalFromRHIdentity(identity);
+            assertEquals("principal", ref.getResource().getResourceType());
+            assertEquals("redhat/7393748", ref.getResource().getResourceId());
+            assertEquals("rbac", ref.getResource().getReporter().getType());
+        }
+
+        @Test
+        void testServiceAccountIdentity() {
+            Map<String, Object> identity = Map.of(
+                    "type", "ServiceAccount",
+                    "org_id", "456",
+                    "service_account",
+                    Map.of("user_id", "sa-456", "client_id", "b69eaf9e", "username", "svc-b69eaf9e"));
+            SubjectReference ref = Console.principalFromRHIdentity(identity);
+            assertEquals("redhat/sa-456", ref.getResource().getResourceId());
+        }
+
+        @Test
+        void testCustomDomain() {
+            Map<String, Object> identity = Map.of(
+                    "type", "User",
+                    "user", Map.of("user_id", "42"));
+            SubjectReference ref = Console.principalFromRHIdentity(identity, "custom");
+            assertEquals("custom/42", ref.getResource().getResourceId());
+        }
+
+        @Test
+        void testUnsupportedTypePropagate() {
+            Map<String, Object> identity = Map.of("type", "System");
+            assertThrows(IllegalArgumentException.class,
+                    () -> Console.principalFromRHIdentity(identity));
+        }
+    }
+
+    private String encodeHeader(Map<String, Object> payload) {
+        try {
+            String json = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(payload);
+            return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    class PrincipalFromRHIdentityHeaderTest {
+        @Test
+        void testFullEnvelope() {
+            String header = encodeHeader(Map.of(
+                    "identity", Map.of(
+                            "type", "User",
+                            "org_id", "1979710",
+                            "user", Map.of("user_id", "7393748", "username", "foobar"))));
+            SubjectReference ref = Console.principalFromRHIdentityHeader(header);
+            assertEquals("redhat/7393748", ref.getResource().getResourceId());
+            assertEquals("principal", ref.getResource().getResourceType());
+        }
+
+        @Test
+        void testMissingIdentityEnvelope() {
+            String header = encodeHeader(Map.of(
+                    "type", "User",
+                    "user", Map.of("user_id", "42")));
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.principalFromRHIdentityHeader(header));
+            assertTrue(ex.getMessage().contains("missing the \"identity\" envelope key"));
+        }
+
+        @Test
+        void testServiceAccountHeader() {
+            String header = encodeHeader(Map.of(
+                    "identity", Map.of(
+                            "type", "ServiceAccount",
+                            "org_id", "456",
+                            "service_account", Map.of("user_id", "sa-789", "client_id", "b69eaf9e"))));
+            SubjectReference ref = Console.principalFromRHIdentityHeader(header);
+            assertEquals("redhat/sa-789", ref.getResource().getResourceId());
+        }
+
+        @Test
+        void testCustomDomain() {
+            String header = encodeHeader(Map.of(
+                    "identity", Map.of(
+                            "type", "User",
+                            "user", Map.of("user_id", "1"))));
+            SubjectReference ref = Console.principalFromRHIdentityHeader(header, "acme");
+            assertEquals("acme/1", ref.getResource().getResourceId());
+        }
+
+        @Test
+        void testMalformedBase64() {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.principalFromRHIdentityHeader("not-valid-base64!!!"));
+            assertTrue(ex.getMessage().contains("Failed to decode identity header"));
+        }
+
+        @Test
+        void testInvalidJson() {
+            String header = Base64.getEncoder().encodeToString("this is not json".getBytes(StandardCharsets.UTF_8));
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.principalFromRHIdentityHeader(header));
+            assertTrue(ex.getMessage().contains("Failed to decode identity header"));
+        }
+
+        @Test
+        void testUnsupportedTypeInHeader() {
+            String header = encodeHeader(Map.of(
+                    "identity", Map.of("type", "System")));
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    () -> Console.principalFromRHIdentityHeader(header));
+            assertTrue(ex.getMessage().contains("Unsupported identity type"));
+        }
+
+        @Test
+        void testRealisticUserHeader() {
+            Map<String, Object> user = new HashMap<>();
+            user.put("username", "rhn-support-foobar");
+            user.put("is_internal", true);
+            user.put("is_org_admin", true);
+            user.put("first_name", "foo");
+            user.put("last_name", "bar");
+            user.put("is_active", true);
+            user.put("user_id", "7393748");
+            user.put("email", "example@redhat.com");
+
+            Map<String, Object> identityInner = new HashMap<>();
+            identityInner.put("account_number", "540155");
+            identityInner.put("org_id", "1979710");
+            identityInner.put("user", user);
+            identityInner.put("type", "User");
+
+            String header = encodeHeader(Map.of("identity", identityInner));
+            SubjectReference ref = Console.principalFromRHIdentityHeader(header);
+            assertEquals("redhat/7393748", ref.getResource().getResourceId());
+            assertEquals("principal", ref.getResource().getResourceType());
+            assertEquals("rbac", ref.getResource().getReporter().getType());
+        }
+
+        @Test
+        void testRealisticServiceAccountHeader() {
+            String header = encodeHeader(Map.of(
+                    "identity", Map.of(
+                            "org_id", "456",
+                            "type", "ServiceAccount",
+                            "service_account", Map.of(
+                                    "user_id", "sa-b69eaf9e",
+                                    "client_id", "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                                    "username", "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd"))));
+            SubjectReference ref = Console.principalFromRHIdentityHeader(header);
+            assertEquals("redhat/sa-b69eaf9e", ref.getResource().getResourceId());
+        }
+    }
+}


### PR DESCRIPTION
Adds `principalFromRHIdentity()` and `principalFromRHIdentityHeader()` to new `Console` pkg, enabling consumers to build principal SubjectReferences directly from platform identity dicts or raw x-rh-identity headers.


https://redhat.atlassian.net/browse/RHCLOUD-46704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Console utility to convert Red Hat identity data into principals, supporting user and service-account identities and customizable domains (default: "redhat").
  * Supports input as parsed identity maps or Base64-encoded identity headers.

* **Examples**
  * Added a console example demonstrating parsing and conversion of various identity inputs and header formats.

* **Tests**
  * Added comprehensive tests covering successful conversions, header parsing, and error cases.

* **Chores**
  * Added a Maven profile to run the console example.
  * Introduced a shared JSON mapper and switched parsing to use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->