### PR TITLE
RHCLOUD-47740  - Add generation locking to prevent thundering herd issue

### DIFF
--- a/docs/performance-guidelines.md
+++ b/docs/performance-guidelines.md
@@ -8,20 +8,21 @@ This document covers concurrency patterns, resource lifecycle, and performance r
 
 ### Architecture
 
-`OAuth2ClientCredentials` implements a double-checked locking pattern for thread-safe token caching:
+`OAuth2ClientCredentials` implements generation-based locking for thread-safe token caching:
 
 - `tokenCache` is declared `volatile` to guarantee visibility across threads.
 - A `ReentrantLock` (`refreshLock`) serializes actual token refresh calls.
+- An `AtomicLong` (`generation`) increments on each successful refresh, enabling waiters to detect that another thread already refreshed.
 - `isCacheValid()` reads the volatile field without locking (fast path).
-- `getToken()` only acquires `refreshLock` when the cache is invalid, then re-checks validity inside the lock (double-check) to avoid redundant refreshes.
+- `getToken()` snapshots the generation counter before acquiring the lock. After acquiring, if the generation changed and the cache is valid, the caller reuses the token the winner fetched -- even for `forceRefresh=true` callers. This prevents the thundering herd problem where N concurrent callers flood SSO with redundant token requests.
 
 The 5-minute `EXPIRATION_WINDOW` causes proactive refresh before actual expiry, preventing auth failures under load.
 
 ### Rules
 
 - **R1**: Create one `OAuth2ClientCredentials` instance per logical service identity. Share it across all stubs and threads. The class is designed for concurrent access.
-- **R2**: Never call `getToken(true)` (force-refresh) in a hot path. Force-refresh bypasses the volatile fast path and always acquires the lock, serializing all callers.
-- **R3**: Do not wrap `getToken()` in external synchronization. The internal `ReentrantLock` already prevents stampede; external locks cause unnecessary contention.
+- **R2**: Avoid calling `getToken(true)` (force-refresh) in hot paths. Force-refresh bypasses the volatile fast path and always acquires the lock. However, concurrent force-refresh callers coalesce via the generation counter -- only one thread performs the SSO call per refresh cycle.
+- **R3**: Do not wrap `getToken()` in external synchronization. The internal `ReentrantLock` + generation counter already prevents stampede; external locks cause unnecessary contention.
 - **R4**: If token refresh fails, `OAuth2Exception` (a `RuntimeException`) propagates to the gRPC `MetadataApplier` as `UNAUTHENTICATED`. Callers should handle `StatusRuntimeException` with `Status.UNAUTHENTICATED` and implement retry logic at the application level.
 - **R5**: `RefreshTokenResponse` and `ClientConfigAuth` are Java records (immutable). They are inherently thread-safe and safe to cache or pass between threads.
 
@@ -107,7 +108,7 @@ The `oauth2-oidc-sdk` dependency is declared `<optional>true</optional>` in `pom
 
 | Component | Thread-safe? | Notes |
 |---|---|---|
-| `OAuth2ClientCredentials` | Yes | volatile + ReentrantLock double-check |
+| `OAuth2ClientCredentials` | Yes | volatile + ReentrantLock + AtomicLong generation counter |
 | `OAuth2CallCredentials` | Yes | Stateless; delegates to thread-safe `OAuth2ClientCredentials` |
 | `ClientConfigAuth` | Yes | Immutable record |
 | `RefreshTokenResponse` | Yes | Immutable record |

--- a/docs/testing-guidelines.md
+++ b/docs/testing-guidelines.md
@@ -183,6 +183,7 @@ The repo tests the following categories -- follow the same coverage pattern:
 4. **Error propagation**: Verify that gRPC/HTTP errors are caught and re-thrown with descriptive messages.
 5. **Record/POJO accessors**: Verify getters return expected values, including `equals`/`hashCode` for records.
 6. **Edge cases for external dependencies**: When testing code that depends on optional libraries (Nimbus OAuth), use `Class.forName` checks or try/catch to skip gracefully.
+7. **Concurrent refresh coalescing**: `OAuth2ClientCredentialsConcurrencyTest` verifies the thundering herd fix. See the concurrency testing section below.
 
 ## Resource Cleanup
 
@@ -193,6 +194,25 @@ Pair<TestStub, ManagedChannel> result = builder.build();
 // assertions...
 result.getRight().shutdown();
 ```
+
+## Concurrency Testing (Thundering Herd)
+
+`OAuth2ClientCredentialsConcurrencyTest` verifies that concurrent `getToken()` callers coalesce into exactly one SSO request per refresh cycle. The test pattern uses:
+
+- **JDK `HttpServer`** as a mock SSO token endpoint (no external dependencies). The handler returns valid OAuth2 token JSON and adds a 50ms delay to widen the race window.
+- **`AtomicInteger`** to count how many times the mock SSO endpoint is hit.
+- **`CountDownLatch` barrier** so all 20 threads enter `getToken()` simultaneously.
+- **Reflection** to pre-seed the private `tokenCache` field with stale or valid tokens.
+
+Three scenarios are tested:
+
+| Test | Setup | Assertion |
+|---|---|---|
+| Stale token refresh | Token expiring in 60s (inside 5-min window) | Exactly 1 SSO call |
+| Cold start | No cached token | Exactly 1 SSO call |
+| Force refresh | Valid cached token + `getToken(true)` | Exactly 1 SSO call |
+
+When adding new concurrency tests, follow this same barrier + call-count pattern.
 
 ## Anti-Patterns to Avoid
 

--- a/kessel-sdk/src/main/java/org/project_kessel/api/auth/OAuth2ClientCredentials.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/auth/OAuth2ClientCredentials.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class OAuth2ClientCredentials {
@@ -23,6 +24,7 @@ public class OAuth2ClientCredentials {
     private final ClientConfigAuth auth;
     private volatile RefreshTokenResponse tokenCache;
     private final ReentrantLock refreshLock = new ReentrantLock();
+    private final AtomicLong generation = new AtomicLong(0);
 
     public OAuth2ClientCredentials(ClientConfigAuth auth) throws OAuth2Exception {
         try {
@@ -55,14 +57,16 @@ public class OAuth2ClientCredentials {
             return tokenCache;
         }
 
+        long snapshot = generation.get();
+
         refreshLock.lock();
         try {
-            // Double-check pattern - another thread might have refreshed while we waited
-            if (!forceRefresh && isCacheValid()) {
+            if (generation.get() != snapshot && isCacheValid()) {
                 return tokenCache;
             }
 
             tokenCache = refresh();
+            generation.incrementAndGet();
             return tokenCache;
         } finally {
             refreshLock.unlock();

--- a/kessel-sdk/src/test/java/org/project_kessel/api/auth/OAuth2ClientCredentialsConcurrencyTest.java
+++ b/kessel-sdk/src/test/java/org/project_kessel/api/auth/OAuth2ClientCredentialsConcurrencyTest.java
@@ -1,0 +1,153 @@
+package org.project_kessel.api.auth;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OAuth2ClientCredentialsConcurrencyTest {
+
+    private static final int NUM_THREADS = 20;
+    private static final int SSO_LATENCY_MS = 50;
+
+    private HttpServer mockSsoServer;
+    private AtomicInteger ssoCallCount;
+    private OAuth2ClientCredentials credentials;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        ssoCallCount = new AtomicInteger(0);
+        mockSsoServer = HttpServer.create(new InetSocketAddress(0), 0);
+        mockSsoServer.createContext("/token", exchange -> {
+            ssoCallCount.incrementAndGet();
+            try {
+                Thread.sleep(SSO_LATENCY_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            String responseBody = """
+                {"access_token":"refreshed-token","token_type":"Bearer","expires_in":3600}""";
+            byte[] bytes = responseBody.getBytes();
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        mockSsoServer.setExecutor(Executors.newFixedThreadPool(NUM_THREADS));
+        mockSsoServer.start();
+
+        int port = mockSsoServer.getAddress().getPort();
+        var config = new ClientConfigAuth("test-client", "test-secret",
+                "http://localhost:" + port + "/token");
+        credentials = new OAuth2ClientCredentials(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mockSsoServer != null) {
+            mockSsoServer.stop(0);
+        }
+    }
+
+    @Test
+    void testConcurrentStaleTokenRefreshCallsSsoOnce() throws Exception {
+        seedTokenCache(credentials,
+                new RefreshTokenResponse("stale-token", LocalDateTime.now().plusSeconds(60)));
+
+        assertFalse(credentials.isCacheValid(),
+                "Pre-seeded token should be inside the 5-min early-refresh window");
+
+        List<RefreshTokenResponse> results = fireConcurrentGetToken(false);
+
+        assertEquals(1, ssoCallCount.get(),
+                "Thundering herd: SSO was called " + ssoCallCount.get()
+                        + " times, expected exactly 1");
+        for (RefreshTokenResponse r : results) {
+            assertEquals("refreshed-token", r.accessToken());
+        }
+    }
+
+    @Test
+    void testConcurrentColdStartCallsSsoOnce() throws Exception {
+        assertFalse(credentials.isCacheValid(), "Cold start should have no cached token");
+
+        List<RefreshTokenResponse> results = fireConcurrentGetToken(false);
+
+        assertEquals(1, ssoCallCount.get(),
+                "Thundering herd: SSO was called " + ssoCallCount.get()
+                        + " times, expected exactly 1");
+        for (RefreshTokenResponse r : results) {
+            assertEquals("refreshed-token", r.accessToken());
+        }
+    }
+
+    @Test
+    void testConcurrentForceRefreshCallsSsoOnce() throws Exception {
+        seedTokenCache(credentials,
+                new RefreshTokenResponse("valid-token", LocalDateTime.now().plusHours(1)));
+
+        assertTrue(credentials.isCacheValid(),
+                "Pre-seeded token should be valid (far from expiry)");
+
+        List<RefreshTokenResponse> results = fireConcurrentGetToken(true);
+
+        assertEquals(1, ssoCallCount.get(),
+                "Thundering herd: SSO was called " + ssoCallCount.get()
+                        + " times, expected exactly 1");
+        for (RefreshTokenResponse r : results) {
+            assertEquals("refreshed-token", r.accessToken());
+        }
+    }
+
+    private List<RefreshTokenResponse> fireConcurrentGetToken(boolean forceRefresh)
+            throws InterruptedException {
+        CountDownLatch barrier = new CountDownLatch(NUM_THREADS);
+        CountDownLatch startGun = new CountDownLatch(1);
+
+        List<Future<RefreshTokenResponse>> futures = new ArrayList<>();
+        ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+
+        try {
+            for (int i = 0; i < NUM_THREADS; i++) {
+                futures.add(executor.submit(() -> {
+                    barrier.countDown();
+                    startGun.await();
+                    return credentials.getToken(forceRefresh);
+                }));
+            }
+
+            barrier.await(5, TimeUnit.SECONDS);
+            startGun.countDown();
+
+            List<RefreshTokenResponse> results = new ArrayList<>();
+            for (Future<RefreshTokenResponse> f : futures) {
+                results.add(f.get(10, TimeUnit.SECONDS));
+            }
+            return results;
+        } catch (ExecutionException | TimeoutException e) {
+            throw new AssertionError("Concurrent getToken() failed", e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void seedTokenCache(OAuth2ClientCredentials creds, RefreshTokenResponse token)
+            throws Exception {
+        Field cacheField = OAuth2ClientCredentials.class.getDeclaredField("tokenCache");
+        cacheField.setAccessible(true);
+        cacheField.set(creds, token);
+    }
+}

--- a/kessel-sdk/src/test/java/org/project_kessel/api/auth/OAuth2ClientCredentialsConcurrencyTest.java
+++ b/kessel-sdk/src/test/java/org/project_kessel/api/auth/OAuth2ClientCredentialsConcurrencyTest.java
@@ -23,6 +23,7 @@ class OAuth2ClientCredentialsConcurrencyTest {
     private static final int SSO_LATENCY_MS = 50;
 
     private HttpServer mockSsoServer;
+    private ExecutorService serverExecutor;
     private AtomicInteger ssoCallCount;
     private OAuth2ClientCredentials credentials;
 
@@ -46,7 +47,8 @@ class OAuth2ClientCredentialsConcurrencyTest {
                 os.write(bytes);
             }
         });
-        mockSsoServer.setExecutor(Executors.newFixedThreadPool(NUM_THREADS));
+        serverExecutor = Executors.newFixedThreadPool(NUM_THREADS);
+        mockSsoServer.setExecutor(serverExecutor);
         mockSsoServer.start();
 
         int port = mockSsoServer.getAddress().getPort();
@@ -56,9 +58,13 @@ class OAuth2ClientCredentialsConcurrencyTest {
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws InterruptedException {
         if (mockSsoServer != null) {
             mockSsoServer.stop(0);
+        }
+        if (serverExecutor != null) {
+            serverExecutor.shutdownNow();
+            serverExecutor.awaitTermination(5, TimeUnit.SECONDS);
         }
     }
 
@@ -129,7 +135,8 @@ class OAuth2ClientCredentialsConcurrencyTest {
                 }));
             }
 
-            barrier.await(5, TimeUnit.SECONDS);
+            assertTrue(barrier.await(5, TimeUnit.SECONDS),
+                    "Not all threads reached the barrier within timeout");
             startGun.countDown();
 
             List<RefreshTokenResponse> results = new ArrayList<>();


### PR DESCRIPTION
- Introduces a way to prevent multiple concurrent calls when ForceRefresh is specified
- Aligned with python SDK code paths






https://redhat.atlassian.net/browse/RHCLOUD-47740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated performance guidelines to describe generation-based concurrent refresh coalescing and updated thread-safety guidance; advises avoiding forced refresh in hot paths
  * Added concurrency testing guidelines with barrier synchronization and call-count verification patterns

* **Tests**
  * New test suite validating concurrent token acquisition across cold start, stale-token early refresh, and forced-refresh scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->