### PR TITLE
RHCLOUD-48469 - Add consistency token support to ListWorkspaces()

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,14 @@ The `ListWorkspaces.listWorkspaces()` helper automatically paginates through
 all workspaces a subject can access. Continuation tokens are handled internally.
 
 ```java
+import org.project_kessel.api.inventory.v1beta2.Consistency;
 import org.project_kessel.api.rbac.v2.ListWorkspaces;
 import org.project_kessel.api.rbac.v2.Utils;
 
+Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
+
 Iterable<StreamedListObjectsResponse> workspaces =
-    ListWorkspaces.listWorkspaces(client, Utils.principalSubject("alice", "redhat"), "viewer");
+    ListWorkspaces.listWorkspaces(client, Utils.principalSubject("alice", "redhat"), "viewer", consistency);
 
 // Lazy iteration (constant memory)
 for (StreamedListObjectsResponse response : workspaces) {

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ import org.project_kessel.api.rbac.v2.Utils;
 Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
 
 Iterable<StreamedListObjectsResponse> workspaces =
-    ListWorkspaces.listWorkspaces(client, Utils.principalSubject("alice", "redhat"), "viewer", consistency);
+    ListWorkspaces.listWorkspaces(client, Utils.principalSubject("alice", "redhat"), "viewer", null, consistency);
 
 // Lazy iteration (constant memory)
 for (StreamedListObjectsResponse response : workspaces) {

--- a/examples/src/main/java/org/project_kessel/examples/ListWorkspacesExample.java
+++ b/examples/src/main/java/org/project_kessel/examples/ListWorkspacesExample.java
@@ -3,9 +3,10 @@ package org.project_kessel.examples;
 import com.nimbusds.jose.util.Pair;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
+import org.project_kessel.api.inventory.v1beta2.ClientBuilder;
+import org.project_kessel.api.inventory.v1beta2.Consistency;
 import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
 import org.project_kessel.api.inventory.v1beta2.StreamedListObjectsResponse;
-import org.project_kessel.api.inventory.v1beta2.ClientBuilder;
 import org.project_kessel.api.rbac.v2.ListWorkspaces;
 import org.project_kessel.api.rbac.v2.Utils;
 import org.project_kessel.examples.util.EnvConfig;
@@ -32,10 +33,12 @@ public class ListWorkspacesExample {
         KesselInventoryServiceBlockingStub client = clientAndChannel.getLeft();
 
         try {
+            Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
             Iterable<StreamedListObjectsResponse> workspaces = ListWorkspaces.listWorkspaces(
                     client,
                     Utils.principalSubject("alice", "redhat"),
-                    "view_document");
+                    "view_document",
+                    consistency);
 
             // Iterate one-by-one (lazy, constant memory)
             System.out.println("Listing all workspaces:");

--- a/examples/src/main/java/org/project_kessel/examples/ListWorkspacesExample.java
+++ b/examples/src/main/java/org/project_kessel/examples/ListWorkspacesExample.java
@@ -38,6 +38,7 @@ public class ListWorkspacesExample {
                     client,
                     Utils.principalSubject("alice", "redhat"),
                     "view_document",
+                    null,
                     consistency);
 
             // Iterate one-by-one (lazy, constant memory)

--- a/kessel-sdk/src/main/java/org/project_kessel/api/rbac/v2/ListWorkspaces.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/rbac/v2/ListWorkspaces.java
@@ -1,5 +1,6 @@
 package org.project_kessel.api.rbac.v2;
 
+import org.project_kessel.api.inventory.v1beta2.Consistency;
 import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
 import org.project_kessel.api.inventory.v1beta2.RequestPagination;
 import org.project_kessel.api.inventory.v1beta2.StreamedListObjectsRequest;
@@ -17,8 +18,10 @@ import java.util.NoSuchElementException;
  *
  * <h3>Lazy iteration (constant memory)</h3>
  * <pre>{@code
+ * Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
+ *
  * Iterable<StreamedListObjectsResponse> workspaces =
- *     ListWorkspaces.listWorkspaces(inventory, subject, "viewer");
+ *     ListWorkspaces.listWorkspaces(inventory, subject, "viewer", consistency);
  *
  * for (StreamedListObjectsResponse response : workspaces) {
  *     System.out.println(response.getObject().getResourceId());
@@ -51,7 +54,7 @@ public class ListWorkspaces {
             KesselInventoryServiceBlockingStub inventory,
             SubjectReference subject,
             String relation) {
-        return listWorkspaces(inventory, subject, relation, null);
+        return listWorkspaces(inventory, subject, relation, null, null);
     }
 
     /**
@@ -69,13 +72,31 @@ public class ListWorkspaces {
             SubjectReference subject,
             String relation,
             String continuationToken) {
-        return () -> new WorkspaceListIterator(inventory, subject, relation, continuationToken);
+        return listWorkspaces(inventory, subject, relation, continuationToken, null);
+    }
+
+    public static Iterable<StreamedListObjectsResponse> listWorkspaces(
+            KesselInventoryServiceBlockingStub inventory,
+            SubjectReference subject,
+            String relation,
+            Consistency consistency) {
+        return listWorkspaces(inventory, subject, relation, null, consistency);
+    }
+
+    public static Iterable<StreamedListObjectsResponse> listWorkspaces(
+            KesselInventoryServiceBlockingStub inventory,
+            SubjectReference subject,
+            String relation,
+            String continuationToken,
+            Consistency consistency) {
+        return () -> new WorkspaceListIterator(inventory, subject, relation, continuationToken, consistency);
     }
 
     private static class WorkspaceListIterator implements Iterator<StreamedListObjectsResponse> {
         private KesselInventoryServiceBlockingStub inventory;
         private SubjectReference subject;
         private String relation;
+        private Consistency consistency;
 
         private String continuationToken;
         private Iterator<StreamedListObjectsResponse> currentPageIterator;
@@ -85,11 +106,13 @@ public class ListWorkspaces {
                 KesselInventoryServiceBlockingStub inventory,
                 SubjectReference subject,
                 String relation,
-                String initialToken) {
+                String initialToken,
+                Consistency consistency) {
             this.inventory = inventory;
             this.subject = subject;
             this.relation = relation;
             this.continuationToken = initialToken;
+            this.consistency = consistency;
             this.currentPageIterator = Collections.emptyIterator();
         }
 
@@ -127,7 +150,7 @@ public class ListWorkspaces {
                 }
 
                 try {
-                    StreamedListObjectsRequest request = buildStreamedListObjectsRequest(subject, relation, continuationToken);
+                    StreamedListObjectsRequest request = buildStreamedListObjectsRequest(subject, relation, continuationToken, consistency);
                     currentPageIterator = inventory.streamedListObjects(request);
                     if (!currentPageIterator.hasNext()) {
                         return false;
@@ -140,7 +163,7 @@ public class ListWorkspaces {
     }
 
     private static StreamedListObjectsRequest buildStreamedListObjectsRequest(
-            SubjectReference subject, String relation, String continuationToken) {
+            SubjectReference subject, String relation, String continuationToken, Consistency consistency) {
 
         StreamedListObjectsRequest.Builder requestBuilder = StreamedListObjectsRequest.newBuilder()
                 .setObjectType(Utils.workspaceType())
@@ -155,6 +178,11 @@ public class ListWorkspaces {
         }
 
         requestBuilder.setPagination(paginationBuilder.build());
+
+        if (consistency != null) {
+            requestBuilder.setConsistency(consistency);
+        }
+
         return requestBuilder.build();
     }
 }

--- a/kessel-sdk/src/main/java/org/project_kessel/api/rbac/v2/ListWorkspaces.java
+++ b/kessel-sdk/src/main/java/org/project_kessel/api/rbac/v2/ListWorkspaces.java
@@ -21,7 +21,7 @@ import java.util.NoSuchElementException;
  * Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
  *
  * Iterable<StreamedListObjectsResponse> workspaces =
- *     ListWorkspaces.listWorkspaces(inventory, subject, "viewer", consistency);
+ *     ListWorkspaces.listWorkspaces(inventory, subject, "viewer", null, consistency);
  *
  * for (StreamedListObjectsResponse response : workspaces) {
  *     System.out.println(response.getObject().getResourceId());
@@ -75,14 +75,18 @@ public class ListWorkspaces {
         return listWorkspaces(inventory, subject, relation, continuationToken, null);
     }
 
-    public static Iterable<StreamedListObjectsResponse> listWorkspaces(
-            KesselInventoryServiceBlockingStub inventory,
-            SubjectReference subject,
-            String relation,
-            Consistency consistency) {
-        return listWorkspaces(inventory, subject, relation, null, consistency);
-    }
-
+    /**
+     * Lists all workspaces the given subject has the specified relation to,
+     * optionally resuming from a previous continuation token and applying the
+     * provided consistency preferences to each paginated request.
+     *
+     * @param inventory         the blocking inventory service stub
+     * @param subject           the subject whose workspace access is being queried
+     * @param relation          the relationship type (e.g. "member", "admin", "viewer")
+     * @param continuationToken optional token to resume from a previous position; may be {@code null}
+     * @param consistency       consistency preferences to include with each request; may be {@code null}
+     * @return a lazily-paginated iterable of responses
+     */
     public static Iterable<StreamedListObjectsResponse> listWorkspaces(
             KesselInventoryServiceBlockingStub inventory,
             SubjectReference subject,

--- a/kessel-sdk/src/test/java/org/project_kessel/api/rbac/v2/ListWorkspacesTest.java
+++ b/kessel-sdk/src/test/java/org/project_kessel/api/rbac/v2/ListWorkspacesTest.java
@@ -241,7 +241,7 @@ class ListWorkspacesTest {
                 .thenReturn(pageIterator)
                 .thenReturn(Collections.emptyIterator());
 
-        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "member", consistency).forEach(response -> {
+        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "member", null, consistency).forEach(response -> {
         });
 
         verify(mockInventoryClient, times(1)).streamedListObjects(requestCaptor.capture());
@@ -276,7 +276,7 @@ class ListWorkspacesTest {
                 .thenReturn(firstPage)
                 .thenReturn(secondPage);
 
-        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "viewer", consistency).forEach(response -> {
+        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "viewer", null, consistency).forEach(response -> {
         });
 
         verify(mockInventoryClient, times(2)).streamedListObjects(requestCaptor.capture());

--- a/kessel-sdk/src/test/java/org/project_kessel/api/rbac/v2/ListWorkspacesTest.java
+++ b/kessel-sdk/src/test/java/org/project_kessel/api/rbac/v2/ListWorkspacesTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.project_kessel.api.inventory.v1beta2.Consistency;
 import org.project_kessel.api.inventory.v1beta2.KesselInventoryServiceGrpc.KesselInventoryServiceBlockingStub;
 import org.project_kessel.api.inventory.v1beta2.ResponsePagination;
 import org.project_kessel.api.inventory.v1beta2.StreamedListObjectsRequest;
@@ -230,6 +231,62 @@ class ListWorkspacesTest {
 
         assertEquals(0, workspaces.size());
         verify(mockInventoryClient, times(1)).streamedListObjects(any(StreamedListObjectsRequest.class));
+    }
+
+    @Test
+    void testConsistencyIsPassedToRequest() {
+        Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
+        Iterator<StreamedListObjectsResponse> pageIterator = List.of(responseWithToken("")).iterator();
+        when(mockInventoryClient.streamedListObjects(any(StreamedListObjectsRequest.class)))
+                .thenReturn(pageIterator)
+                .thenReturn(Collections.emptyIterator());
+
+        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "member", consistency).forEach(response -> {
+        });
+
+        verify(mockInventoryClient, times(1)).streamedListObjects(requestCaptor.capture());
+        StreamedListObjectsRequest capturedRequest = requestCaptor.getAllValues().get(0);
+
+        assertTrue(capturedRequest.hasConsistency());
+        assertEquals(consistency, capturedRequest.getConsistency());
+    }
+
+    @Test
+    void testNullConsistencyDoesNotSetField() {
+        Iterator<StreamedListObjectsResponse> pageIterator = List.of(responseWithToken("")).iterator();
+        when(mockInventoryClient.streamedListObjects(any(StreamedListObjectsRequest.class)))
+                .thenReturn(pageIterator)
+                .thenReturn(Collections.emptyIterator());
+
+        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "member").forEach(response -> {
+        });
+
+        verify(mockInventoryClient, times(1)).streamedListObjects(requestCaptor.capture());
+        StreamedListObjectsRequest capturedRequest = requestCaptor.getAllValues().get(0);
+
+        assertFalse(capturedRequest.hasConsistency());
+    }
+
+    @Test
+    void testConsistencyIsPreservedAcrossPaginatedRequests() {
+        Consistency consistency = Consistency.newBuilder().setMinimizeLatency(true).build();
+        Iterator<StreamedListObjectsResponse> firstPage = List.of(responseWithToken("next-page-token")).iterator();
+        Iterator<StreamedListObjectsResponse> secondPage = List.of(responseWithToken("")).iterator();
+        when(mockInventoryClient.streamedListObjects(any(StreamedListObjectsRequest.class)))
+                .thenReturn(firstPage)
+                .thenReturn(secondPage);
+
+        ListWorkspaces.listWorkspaces(mockInventoryClient, testSubject, "viewer", consistency).forEach(response -> {
+        });
+
+        verify(mockInventoryClient, times(2)).streamedListObjects(requestCaptor.capture());
+        List<StreamedListObjectsRequest> requests = requestCaptor.getAllValues();
+
+        assertEquals(2, requests.size());
+        assertTrue(requests.get(0).hasConsistency());
+        assertEquals(consistency, requests.get(0).getConsistency());
+        assertTrue(requests.get(1).hasConsistency());
+        assertEquals(consistency, requests.get(1).getConsistency());
     }
 
     private static StreamedListObjectsResponse responseWithToken(String token) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHCLOUD-48469

## Summary
- add `ListWorkspaces` overloads that accept an optional `Consistency` and propagate it to each paginated `StreamedListObjectsRequest`
- preserve the existing helper behavior by delegating older overloads to the new signature with `null` continuation token and consistency
- update the README and runnable example to show passing a consistency preference, and add tests covering present, absent, and paginated consistency handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring gRPC consistency options when listing workspaces, enabling selection of latency vs. consistency behavior.

* **Documentation**
  * Updated the workspace listing example and README to show how to create and pass a consistency configuration.

* **Tests**
  * Added unit tests to verify consistency is applied to list requests, omitted when not provided, and preserved across paginated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->